### PR TITLE
Adding "Go back" button

### DIFF
--- a/index.php
+++ b/index.php
@@ -76,6 +76,10 @@ if (!empty($action)) {
     }
 }
 
+// Add a "Go Back" button.
+$gobackurl = new \moodle_url('/course/view.php', array('id' => $courseid));
+$goback = $OUTPUT->single_button($gobackurl, get_string('goback', 'local_recyclebin'), 'get');
+
 // Output header.
 echo $OUTPUT->header();
 echo $OUTPUT->heading($PAGE->title);
@@ -86,6 +90,7 @@ $items = $recyclebin->get_items();
 // Nothing to show? Bail out early.
 if (empty($items)) {
     echo $OUTPUT->box(get_string('emptybin', 'local_recyclebin'));
+    echo $goback;
     echo $OUTPUT->footer();
     die;
 }
@@ -199,6 +204,8 @@ if (has_capability('local/recyclebin:empty', $coursecontext)) {
         'class' => 'singlebutton recycle-bin-delete-all'
     ));
 }
+
+echo $goback;
 
 // Confirmation JS.
 $PAGE->requires->strings_for_js(array('emptyconfirm', 'deleteconfirm'), 'local_recyclebin');

--- a/lang/en/local_recyclebin.php
+++ b/lang/en/local_recyclebin.php
@@ -60,3 +60,4 @@ $string['descriptionexpiry'] = 'Contents will be permanently deleted after {$a} 
 $string['emptybin'] = 'There are no items in the recycle bin.';
 $string['emptyconfirm'] = 'Are you sure you want to delete all items in the recycle bin?';
 $string['deleteconfirm'] = 'Are you sure you want to delete the selected item(s) in the recycle bin?';
+$string['goback'] = 'Go back';


### PR DESCRIPTION
- Created css file and styling Recycle Bin links to look like buttons.

This is a change that might be a little hard to swallow. But we found that our users wanted a "Go back" button, even though they can click on the breadcrumbs to go back.

Also, our users didn't like that the Empty was a link and not a button. So this patch also styles the links to look like buttons. However, the styling of the button matches our school's color/theme. So I don't know how to make it more generalized unless we use Moodle's form API to make them into look like the same buttons you see when you add/edit course modules. But that makes the code much more difficult to read.
