### PR TITLE
Renamed Empty to Delete all

### DIFF
--- a/lang/en/local_recyclebin.php
+++ b/lang/en/local_recyclebin.php
@@ -35,7 +35,7 @@ $string['autohide_desc'] = 'Automatically hides the recycle bin link when the bi
 
 $string['neverdelete'] = 'Never delete recycled items';
 $string['deleted'] = 'Date deleted';
-$string['empty'] = 'Empty recycle bin';
+$string['empty'] = 'Delete all';
 
 $string['recyclebin:view'] = 'View recycle bin items';
 $string['recyclebin:restore'] = 'Restore recycle bin items';


### PR DESCRIPTION
We renamed the phrase "Empty recycle bin" to "Delete all". I know that the metaphor of the recycle bin has been a widely known thing, we still felt like changing the wording to "Delete all" is a more straightforward phrase. Let us know what you think.
