### PR TITLE
Adding 14 and 21 days as expiry config options.

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -40,6 +40,8 @@ if ($hassiteconfig) {
         90   => new lang_string('numdays', '', 90),
         60   => new lang_string('numdays', '', 60),
         35   => new lang_string('numdays', '', 35),
+        21   => new lang_string('numdays', '', 21),
+        14   => new lang_string('numdays', '', 14),
         10   => new lang_string('numdays', '', 10),
         5    => new lang_string('numdays', '', 5),
         2    => new lang_string('numdays', '', 2)


### PR DESCRIPTION
We could that there was a big gap between the given 35 days and 10 days options. Our system admin wanted us to set the expiry to either 21 days (3 weeks) or 14 days (2 weeks).

This patch supports that ability.
